### PR TITLE
mark-devkit: Bump dev-qt/qtbluetooth-5.15.16-r1

### DIFF
--- a/dev-qt/qtbluetooth/qtbluetooth-5.15.16-r1.ebuild
+++ b/dev-qt/qtbluetooth/qtbluetooth-5.15.16-r1.ebuild
@@ -20,6 +20,7 @@ DEPEND="${RDEPEND}
 	dev-qt/qtnetwork:5
 	
 "
+S="${WORKDIR}/qtconnectivity-everywhere-src-5.15.16"
 src_prepare() {
 	sed -i -e 's/nfc//' src/src.pro || die
 	qt_use_disable_mod qml quick src/src.pro


### PR DESCRIPTION
Automatic bump of package dev-qt/qtbluetooth-5.15.16-r1 for branch mark-unstable by mark-bot