### PR TITLE
mark-devkit: Bump dev-python/PyQtWebEngine-5.15.7-r1

### DIFF
--- a/dev-python/PyQtWebEngine/PyQtWebEngine-5.15.7-r1.ebuild
+++ b/dev-python/PyQtWebEngine/PyQtWebEngine-5.15.7-r1.ebuild
@@ -1,37 +1,39 @@
 # Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
 
 EAPI=7
 
 PYTHON_COMPAT=( python3+ )
 inherit python-r1 qmake-utils
 
-DESCRIPTION="Python bindings for QtWebEngine"
+DESCRIPTION="Python bindings for the Qt WebEngine framework"
 HOMEPAGE="https://www.riverbankcomputing.com/software/pyqtwebengine/ https://pypi.org/project/PyQtWebEngine/"
-SRC_URI="https://files.pythonhosted.org/packages/18/e8/19a00646866e950307f8cd73841575cdb92800ae14837d5821bcbb91392c/PyQtWebEngine-5.15.7.tar.gz -> PyQtWebEngine-5.15.7.tar.gz"
-
-LICENSE="GPL-3"
-SLOT="0"
-KEYWORDS="*"
-IUSE="debug"
-
-REQUIRED_USE="
-	${PYTHON_REQUIRED_USE}
+SRC_URI="https://files.pythonhosted.org/packages/18/e8/19a00646866e950307f8cd73841575cdb92800ae14837d5821bcbb91392c/PyQtWebEngine-5.15.7.tar.gz -> PyQtWebEngine-5.15.7.tar.gz
 "
+CDEPEND="
 
-DEPEND="${PYTHON_DEPS}
-	>=dev-python/PyQt5-5.15.5[gui,network,printsupport,ssl,webchannel,widgets,${PYTHON_USEDEP}]
+	${PYTHON_DEPS}
+	dev-python/PyQt5:5[gui,network,printsupport,ssl,webchannel,widgets,${PYTHON_USEDEP}]
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtwebengine:5[widgets]
 "
-RDEPEND="${DEPEND}
-	>=dev-python/PyQt5-sip-12.9:=[${PYTHON_USEDEP}]
+DEPEND="${CDEPEND}
+"
+RDEPEND="
+	${CDEPEND}
+	dev-python/PyQt5-sip:=[${PYTHON_USEDEP}]
 "
 BDEPEND="
-	>=dev-python/PyQt-builder-1.10[${PYTHON_USEDEP}]
-	>=dev-python/sip-6.2[${PYTHON_USEDEP}]
-	dev-qt/qtcore:5
+	dev-python/PyQt-builder[${PYTHON_USEDEP}]
+	dev-python/sip[${PYTHON_USEDEP}]
 "
+
+IUSE="debug"
+SLOT="0"
+LICENSE="GPL-3"
+KEYWORDS="*"
+S="${WORKDIR}/PyQtWebEngine-5.15.7"
 
 src_configure() {
 	configuration() {
@@ -52,11 +54,9 @@ src_configure() {
 	}
 	python_foreach_impl configuration
 }
-
 src_compile() {
 	python_foreach_impl run_in_build_dir default
 }
-
 src_install() {
 	installation() {
 		emake INSTALL_ROOT="${D}" install
@@ -66,3 +66,4 @@ src_install() {
 
 	einstalldocs
 }
+


### PR DESCRIPTION
Automatic bump of package dev-python/PyQtWebEngine-5.15.7-r1 for branch mark-iii by mark-bot