### PR TITLE
mark-devkit: [mark-unstable] Bump dev-python/PyQt-builder-1.18.2-r1

### DIFF
--- a/dev-python/PyQt-builder/PyQt-builder-1.18.2-r1.ebuild
+++ b/dev-python/PyQt-builder/PyQt-builder-1.18.2-r1.ebuild
@@ -29,10 +29,9 @@ post_src_unpack() {
 }
 
 src_prepare() {
-	# This is needed until we have setuptoos_scm-8
-	sed -i -e "s|^dynamic.*|version = \"${PV}\"|g" \
-		-e '/^version_file.*/d' \
-		pyproject.toml
+	sed -i -e 's/license =.*/license = { text = "BSD" }/' \
+		-e '/^license-files.*/d' \
+		pyproject.toml || die
 	distutils-r1_src_prepare
 }
 


### PR DESCRIPTION
Automatic bump of package dev-python/PyQt-builder-1.18.2-r1 for branch mark-unstable by mark-bot