### PR TITLE
mark-devkit: [mark-31] Bump dev-qt/qtbase-6.10.1-r1

### DIFF
--- a/dev-qt/qtbase/qtbase-6.10.1-r1.ebuild
+++ b/dev-qt/qtbase/qtbase-6.10.1-r1.ebuild
@@ -74,7 +74,10 @@ RDEPEND="sys-libs/zlib
 DEPEND="${RDEPEND}
 "
 PDEPEND="gui? (
-	  wayland? ( ~dev-qt/qtwayland-${PV}:6 )
+		wayland? (
+			~dev-qt/qtwayland-${PV}:6
+			!<dev-qt/qtwayland-6.10:6
+		)
 	)
 	
 "


### PR DESCRIPTION
Automatic bump of package dev-qt/qtbase-6.10.1-r1 for branch mark-31 by mark-bot